### PR TITLE
Memory leak fix KnapsackSolver; for java proxy

### DIFF
--- a/src/algorithms/java/knapsack_solver.swig
+++ b/src/algorithms/java/knapsack_solver.swig
@@ -31,6 +31,7 @@
 %unignore operations_research;
 %unignore operations_research::KnapsackSolver;
 %unignore operations_research::KnapsackSolver::KnapsackSolver;
+%unignore operations_research::KnapsackSolver::~KnapsackSolver;
 %rename (init) operations_research::KnapsackSolver::Init;
 %rename (solve) operations_research::KnapsackSolver::Solve;
 %rename (bestSolutionContains)


### PR DESCRIPTION
Because the destructor is not disclosed the memory does not get freed. Added to configuration file and tested thoroughly.